### PR TITLE
Support different ssl configuration for old versions of mysql5.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ ENV OTTERTUNE_OVERRIDE_SERVER_URL="https://api.ottertune.com"
 RUN mkdir -p /ottertune/driver
 COPY . /ottertune/driver
 WORKDIR /ottertune/driver
+RUN cp /usr/lib/ssl/openssl.cnf /usr/lib/ssl/openssl_cipher1.cnf && \
+    sed -i "s/\(CipherString *= *\).*/\1DEFAULT@SECLEVEL=1 /" "/usr/lib/ssl/openssl_cipher1.cnf"
 
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
Quick fix until maybe a more programatic solution down the road:

User supplies `--env OPENSSL_CONF=/usr/lib/ssl/openssl_cipher1.cnf` when running docker command