### PR TITLE
Use python 3.9.9 to have less strict DH cipher requirement for old version mysql

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # Postgres only:
 # POSTGRES_OTTERTUNE_DB_NAME - Specific database in DBMS to collect metrics from
 
-FROM python:3.10.1-slim-bullseye
+FROM python:3.9.9-slim-bullseye
 
 ENV OTTERTUNE_OVERRIDE_SERVER_URL="https://api.ottertune.com"
 ENV OTTERTUNE_OVERRIDE_NUM_TABLE_TO_COLLECT_STATS="1000"

--- a/driver/compute_server_client.py
+++ b/driver/compute_server_client.py
@@ -17,7 +17,7 @@ RETRYABLE_HTTP_STATUS: Set[int] = {
 }
 
 # TODO: move this elsewhere and have it pull from git tags as source of truth
-AGENT_VERSION = "0.3.7"
+AGENT_VERSION = "0.3.8"
 
 
 class DBLevelObservation(TypedDict):


### PR DESCRIPTION
# What
Python 3.10.1 used an OpenSSL version which has a more strict requirement on DH ciphers. Searching online shows that many people suggest setting DEFAULT@SECLEVEL to 1 ([link](https://bugs.python.org/issue46136)), which we already did. And I also tried to restrict ciphers to non-DH ones but it seems not to work, which just looks like the conf file was useless.

This PR is to block the user.

# Background
https://ottertune-community.slack.com/archives/C02FS9JJVGW/p1654174805984429


# Test Plan
Tested with the docker image. Both target MySQL version and the other MySQL version are good with this.
