### PR TITLE
Add db_non_default_parameters in RDS config

### DIFF
--- a/driver/aws/rds.py
+++ b/driver/aws/rds.py
@@ -104,9 +104,9 @@ def get_db_parameter_group_name(db_instance_identifier: str, client: RDSClient) 
     """
     db_parameter_group_name = ""
     instance_info = get_db_instance_info(db_instance_identifier, client)
-    parameter_groups = instance_info.get("DBParameterGroups", "")
+    parameter_groups = instance_info.get("DBParameterGroups")
     if parameter_groups:
-        db_parameter_group_name = parameter_groups[0].get("DBParameterGroupName", "")
+        db_parameter_group_name = parameter_groups[0].get("DBParameterGroupName")
 
     if not db_parameter_group_name:
         logging.warning(
@@ -142,10 +142,10 @@ def get_db_non_default_parameters(
             )
 
         db_non_default_parameters = [
-            parameter.get("ParameterName", "")
+            parameter.get("ParameterName")
             for parameter in db_parameters
-            if parameter.get("Source", "") == "user"
-            and parameter.get("ParameterName", "")
+            if parameter.get("Source") == "user"
+            and "ParameterName" in parameter
         ]
     else:
         logging.warning(

--- a/driver/aws/rds.py
+++ b/driver/aws/rds.py
@@ -108,6 +108,12 @@ def get_db_parameter_group_name(db_instance_identifier: str, client: RDSClient) 
     if parameter_groups:
         db_parameter_group_name = parameter_groups[0].get("DBParameterGroupName", "")
 
+    if not db_parameter_group_name:
+        logging.warning(
+            "RDS client: Unable to get parameter group name for instance %s",
+            db_instance_identifier,
+        )
+
     return db_parameter_group_name
 
 
@@ -143,7 +149,7 @@ def get_db_non_default_parameters(
         ]
     else:
         logging.warning(
-            "RDS client: Unable to get parameter group name for instance %s",
+            "RDS client: Cannot fetch parameters without parameter group name for instance %s",
             db_instance_identifier,
         )
 

--- a/driver/aws/rds.py
+++ b/driver/aws/rds.py
@@ -95,3 +95,33 @@ def get_db_type(db_instance_identifier: str, client: RDSClient) -> str:
     if db_type == "aurora":  # for aurora mysql 5.6
         db_type = "aurora_mysql"
     return db_type
+
+
+def get_db_parameter_group_name(db_instance_identifier: str, client: RDSClient) -> str:
+    """
+    Get database parameter group name
+    """
+    instance_info = get_db_instance_info(db_instance_identifier, client)
+    return instance_info["DBParameterGroups"][0]["DBParameterGroupName"]
+
+
+def get_db_non_default_parameters(
+    db_instance_identifier: str, client: RDSClient
+) -> str:
+    """
+    Get list of database parameters that are set by the user
+    """
+    db_non_default_parameters = []
+    db_parameter_group_name = get_db_parameter_group_name(
+        db_instance_identifier, client
+    )
+
+    response = client.describe_db_parameters(DBParameterGroupName=db_parameter_group_name)
+
+    db_non_default_parameters = [
+        parameter["ParameterName"]
+        for parameter in resp["Parameters"]
+        if parameter["Source"] == "user"
+    ]
+
+    return db_non_default_parameters

--- a/driver/aws/rds.py
+++ b/driver/aws/rds.py
@@ -129,7 +129,7 @@ def get_db_non_default_parameters(
                 DBParameterGroupName=db_parameter_group_name
             )
             db_parameters = response["Parameters"]
-        except KeyError() as ex:
+        except KeyError as ex:
             logging.warning(
                 "RDS client: Unable to collect parameters for Parameter Group Name %s",
                 db_parameter_group_name,

--- a/driver/aws/rds.py
+++ b/driver/aws/rds.py
@@ -128,9 +128,8 @@ def get_db_non_default_parameters(
             response = client.describe_db_parameters(
                 DBParameterGroupName=db_parameter_group_name
             )
-            response.raise_for_status()
-            db_parameters = response.get("Parameters", [])
-        except Exception as ex:
+            db_parameters = response["Parameters"]
+        except KeyError() as ex:
             logging.warning(
                 "RDS client: Unable to collect parameters for Parameter Group Name %s",
                 db_parameter_group_name,

--- a/driver/aws/rds.py
+++ b/driver/aws/rds.py
@@ -107,7 +107,7 @@ def get_db_parameter_group_name(db_instance_identifier: str, client: RDSClient) 
 
 def get_db_non_default_parameters(
     db_instance_identifier: str, client: RDSClient
-) -> str:
+) -> List[str]:
     """
     Get list of database parameters that are set by the user
     """

--- a/driver/aws/rds.py
+++ b/driver/aws/rds.py
@@ -120,7 +120,7 @@ def get_db_non_default_parameters(
 
     db_non_default_parameters = [
         parameter["ParameterName"]
-        for parameter in resp["Parameters"]
+        for parameter in response["Parameters"]
         if parameter["Source"] == "user"
     ]
 

--- a/driver/compute_server_client.py
+++ b/driver/compute_server_client.py
@@ -1,7 +1,7 @@
 """Defines the compute server client that interacts with the server with http requests"""
 
 import json
-from typing import Dict, Any, TypedDict, Set
+from typing import List, Dict, Any, TypedDict, Set
 from http import HTTPStatus
 from requests import Session
 
@@ -31,6 +31,7 @@ class DBLevelObservation(TypedDict):
     ]  # summary information like observation time, database version, etc
     db_key: str
     organization_id: str
+    non_default_knobs: List[str]
 
 
 class TableLevelObservation(TypedDict):

--- a/driver/database.py
+++ b/driver/database.py
@@ -95,6 +95,7 @@ def collect_db_level_data_from_database(driver_conf: Dict[str, Any]) -> DBLevelO
         "row_num_stats": row_num_stats,
         "db_key": driver_conf["db_key"],
         "organization_id": driver_conf["organization_id"],
+        "non_default_knobs": driver_conf["db_non_default_parameters"]
     }
     return observation
 

--- a/driver/driver_config_builder.py
+++ b/driver/driver_config_builder.py
@@ -186,9 +186,7 @@ class DriverConfig(NamedTuple):  # pylint: disable=too-many-instance-attributes
     disable_index_stats: bool
     num_index_to_collect_stats: int
 
-    db_non_default_parameters: List[
-        str
-    ]
+    db_non_default_parameters: List[str]
 
 
 class DriverConfigBuilder(BaseDriverConfigBuilder):

--- a/driver/driver_config_builder.py
+++ b/driver/driver_config_builder.py
@@ -139,9 +139,7 @@ class PartialConfigFromRDS(BaseModel):  # pyre-ignore[13]: pydantic uninitialize
     db_port: StrictInt
     db_version: StrictStr
     db_type: StrictStr
-    db_non_default_parameters: List[
-        str
-    ]
+    db_non_default_parameters: List[str]
 
 
 class PartialConfigFromCloudwatchMetrics(BaseModel):  # pyre-ignore[13]: uninitialized variables

--- a/driver/driver_config_builder.py
+++ b/driver/driver_config_builder.py
@@ -18,7 +18,13 @@ from pydantic import (
 )
 import yaml
 
-from driver.aws.rds import get_db_version, get_db_port, get_db_hostname, get_db_type
+from driver.aws.rds import (
+    get_db_version,
+    get_db_port,
+    get_db_hostname,
+    get_db_type,
+    get_db_non_default_parameters,
+)
 from driver.aws.wrapper import AwsWrapper
 from driver.exceptions import DriverConfigException
 
@@ -133,6 +139,9 @@ class PartialConfigFromRDS(BaseModel):  # pyre-ignore[13]: pydantic uninitialize
     db_port: StrictInt
     db_version: StrictStr
     db_type: StrictStr
+    db_non_default_parameters: List[
+        str
+    ]
 
 
 class PartialConfigFromCloudwatchMetrics(BaseModel):  # pyre-ignore[13]: uninitialized variables
@@ -176,6 +185,10 @@ class DriverConfig(NamedTuple):  # pylint: disable=too-many-instance-attributes
     table_level_monitor_interval: int
     disable_index_stats: bool
     num_index_to_collect_stats: int
+
+    db_non_default_parameters: List[
+        str
+    ]
 
 
 class DriverConfigBuilder(BaseDriverConfigBuilder):
@@ -272,7 +285,10 @@ class DriverConfigBuilder(BaseDriverConfigBuilder):
             "db_host": get_db_hostname(db_instance_identifier, self.rds_client),
             "db_port": get_db_port(db_instance_identifier, self.rds_client),
             "db_version": get_db_version(db_instance_identifier, self.rds_client),
-            "db_type": get_db_type(db_instance_identifier, self.rds_client)
+            "db_type": get_db_type(db_instance_identifier, self.rds_client),
+            "db_non_default_parameters": get_db_non_default_parameters(
+                db_instance_identifier, self.rds_client
+            )
         }
 
         try:

--- a/tests/config_builder_test.py
+++ b/tests/config_builder_test.py
@@ -11,6 +11,7 @@ import pytest
 
 from driver.driver_config_builder import (
     PartialConfigFromFile,
+    PartialConfigFromRDS,
     DriverConfigBuilder,
 )
 
@@ -58,13 +59,23 @@ def _test_config_data() -> Dict[str, Any]:
         "tune_interval": 600,
     }
 
+    partial_config_from_rds: Dict[str, Any] = {
+        "db_type": "mysql",
+        "db_host": "test_host",
+        "db_port": 3306,
+        "db_version": "14_2",
+        "db_non_default_parameters": ['test_parameter_1', 'test_parameter_2']
+    }
+
     config: Dict[str, Any] = {}
     config.update(partial_config_from_file)
     config.update(partial_config_from_server)
+    config.update(partial_config_from_rds)
 
     return dict(
         file=partial_config_from_file,
         server=partial_config_from_server,
+        rds=partial_config_from_rds,
     )
 
 
@@ -120,6 +131,42 @@ def test_partial_config_from_file_missing_value(
     with pytest.raises(ValidationError) as ex:
         PartialConfigFromFile(**test_data_from_file)
     assert "server_url" in str(ex.value)
+
+
+# Test PartialConfigFromRDS
+def test_partial_config_from_rds_success(
+    test_config_data: Dict[str, Any]
+) -> None:
+    # rds config success: all key values intact 
+    test_data_from_rds = test_config_data["rds"]
+    partial_config = PartialConfigFromRDS(**test_data_from_rds)
+    assert partial_config.db_type == "mysql"
+    assert partial_config.db_host == "test_host"
+    assert partial_config.db_port == 3306
+    assert partial_config.db_version == "14_2"
+    assert partial_config.db_non_default_parameters == ['test_parameter_1', 'test_parameter_2']
+
+
+def test_partial_config_from_file_invalid_type(
+    test_config_data: Dict[str, Any]
+) -> None:
+    # wrong type db_version fetched from env, string is expected, but int found
+    test_data_from_rds = test_config_data["rds"]
+    test_data_from_rds["db_version"] = 10
+    with pytest.raises(ValidationError) as ex:
+        PartialConfigFromRDS(**test_data_from_rds)
+    assert "db_version" in str(ex.value)
+
+
+def test_partial_config_from_file_missing_value(
+    test_config_data: Dict[str, Any]
+) -> None:
+    # missing option db_non_default_parameters fetched from rds
+    test_data_from_rds = test_config_data["rds"]
+    test_data_from_rds.pop("db_non_default_parameters")
+    with pytest.raises(ValidationError) as ex:
+        PartialConfigFromRDS(**test_data_from_rds)
+    assert "db_non_default_parameters" in str(ex.value)
 
 
 def test_create_driver_config_builder_invalid_config_path() -> None:

--- a/tests/config_builder_test.py
+++ b/tests/config_builder_test.py
@@ -137,7 +137,7 @@ def test_partial_config_from_file_missing_value(
 def test_partial_config_from_rds_success(
     test_config_data: Dict[str, Any]
 ) -> None:
-    # rds config success: all key values intact 
+    # rds config success: all key values intact
     test_data_from_rds = test_config_data["rds"]
     partial_config = PartialConfigFromRDS(**test_data_from_rds)
     assert partial_config.db_type == "mysql"
@@ -147,7 +147,7 @@ def test_partial_config_from_rds_success(
     assert partial_config.db_non_default_parameters == ['test_parameter_1', 'test_parameter_2']
 
 
-def test_partial_config_from_file_invalid_type(
+def test_partial_config_from_rds_invalid_type(
     test_config_data: Dict[str, Any]
 ) -> None:
     # wrong type db_version fetched from env, string is expected, but int found
@@ -158,7 +158,7 @@ def test_partial_config_from_file_invalid_type(
     assert "db_version" in str(ex.value)
 
 
-def test_partial_config_from_file_missing_value(
+def test_partial_config_from_rds_missing_value(
     test_config_data: Dict[str, Any]
 ) -> None:
     # missing option db_non_default_parameters fetched from rds

--- a/tests/db_test_mysql.py
+++ b/tests/db_test_mysql.py
@@ -74,6 +74,7 @@ def _get_driver_conf(
         "organization_id": "test_organization",
         "num_table_to_collect_stats": num_table_to_collect_stats,
         "num_index_to_collect_stats": num_index_to_collect_stats,
+        "db_non_default_parameters": ['test_parameter_1', 'test_parameter_2']
     }
     return conf
 

--- a/tests/db_test_mysql.py
+++ b/tests/db_test_mysql.py
@@ -2,7 +2,7 @@
 import json
 import time
 
-from typing import Dict, Any, Union
+from typing import List, Dict, Any, Union
 import mysql.connector
 
 from driver.collector.collector_factory import get_mysql_version, connect_mysql
@@ -60,7 +60,7 @@ def _get_driver_conf(
     mysql_database: str,
     num_table_to_collect_stats: int,
     num_index_to_collect_stats: int,
-) -> Dict[str, Union[int, str]]:
+) -> Dict[str, Union[int, str, List[str]]]:
     # pylint: disable=too-many-arguments
     conf = {
         "db_user": mysql_user,

--- a/tests/db_test_postgres.py
+++ b/tests/db_test_postgres.py
@@ -50,6 +50,7 @@ def _get_driver_conf(
         "organization_id": "test_organization",
         "num_table_to_collect_stats": num_table_to_collect_stats,
         "num_index_to_collect_stats": num_index_to_collect_stats,
+        "db_non_default_parameters": ['test_parameter_1', 'test_parameter_2']
     }
     return conf
 


### PR DESCRIPTION
~~Draft, will update unit tests once approach is vetted for :)~~ Done

# What
- We want the agent to also record which parameters have been set to default, by using the existing RDS client
- which will in turn be stored in the field created at https://github.com/ottertune/models/pull/331 which is intended to store

    > A list of parameter names set to a non-default (user-set) value

- in a separate key called **db_non_default_parameters**, which has a similar name as the aforementioned field
- and avoids storing any more info than we need to not bloat the response significantly (especially since the only RDS things we currently pass are strings)
- will not affect the compute service if released before, as the presence of additional keys is not checked.


A sample of resultant config, with the added part in bold:
`DriverConfig(server_url='https://dev.api.ottertune.com', db_identifier='bug-bash-pg-14', aws_region='us-east-2', db_type='postgres', db_host='bug-bash-pg-14.csmbpj48k8gh.us-east-2.rds.amazonaws.com', db_port=5432, db_version='14_2', db_user='ottertune', db_password='ottertune', db_name='postgres', api_key='cHNcTsM2qhxYgLc7KSXNee9DBQBPBdL+J1+pKmETcmk=', db_key='a468086d-192a-456d-96bd-14f23f138108', organization_id='978a5fa7-3a7f-4ad8-9a20-670d898736cf', monitor_interval=60, metric_source=['cloudwatch'], metrics_to_retrieve_from_source={'cloudwatch': ['BurstBalance', 'CPUUtilization', 'CPUCreditUsage', 'CPUCreditBalance', 'CPUSurplusCreditBalance', 'CPUSurplusCreditsCharged', 'DatabaseConnections', 'DiskQueueDepth', 'FreeableMemory', 'FreeStorageSpace', 'MaximumUsedTransactionIDs', 'NetworkReceiveThroughput', 'NetworkTransmitThroughput', 'OldestReplicationSlotLag', 'ReadIOPS', 'ReadLatency', 'ReadThroughput', 'ReplicaLag', 'ReplicationSlotDiskUsage', 'SwapUsage', 'TransactionLogsDiskUsage', 'TransactionLogsGeneration', 'WriteIOPS', 'WriteLatency', 'WriteThroughput']}, disable_table_level_stats=False, num_table_to_collect_stats=1000, table_level_monitor_interval=3600, disable_index_stats=False, num_index_to_collect_stats=10000, `**`db_non_default_parameters=['auto_explain.log_min_duration', 'autovacuum_analyze_scale_factor', 'autovacuum_vacuum_cost_delay', 'autovacuum_vacuum_cost_limit', 'autovacuum_vacuum_scale_factor', 'autovacuum_vacuum_threshold', 'bgwriter_delay', 'bgwriter_lru_maxpages', 'bgwriter_lru_multiplier', 'checkpoint_completion_target', 'default_statistics_target', 'effective_cache_size', 'effective_io_concurrency'])`**

And part of the observation:
`... "10_16384_-7593003187313059317", "calls": 1, "avg_time_ms": 0.265968}, {"queryid": "24596_16397_-10548271148330687", "calls": 1, "avg_time_ms": 0.270024}, {"queryid": "10_16384_592501746573523553", "calls": 690, "avg_time_ms": 0.9225315492753621}, {"queryid": "16395_16397_7393754874379183925", "calls": 2, "avg_time_ms": 1244.4313035}, {"queryid": "10_16384_-2921278556263144409", "calls": 1, "avg_time_ms": 0.289574}, {"queryid": "10_16384_-7680128766412186291", "calls": 98, "avg_time_ms": 0.005259561224489796}, {"queryid": "10_16384_-3691625095440945416", "calls": 533, "avg_time_ms": 6.450948073170736}, {"queryid": "16395_16397_-6861357829720807231", "calls": 2, "avg_time_ms": 0.009805000000000001}, {"queryid": "10_16384_-7708511618875264063", "calls": 103, "avg_time_ms": 0.003537932038834951}, {"queryid": "16395_16397_756742628567528570", "calls": 1, "avg_time_ms": 0.143817}, {"queryid": "10_16384_3869979776738321569", "calls": 92188, "avg_time_ms": 0.12332254312925904}, {"queryid": "16395_16397_7592958026581161144", "calls": 62979, "avg_time_ms": 0.0332568868988075}, {"queryid": "16395_16397_3475236018953252415", "calls": 2, "avg_time_ms": 664.7704695}, {"queryid": "16395_16397_3590143226477921812", "calls": 1, "avg_time_ms": 2.148778}, {"queryid": "10_16384_-6835706900671045879", "calls": 1, "avg_time_ms": 0.188919}, {"queryid": "10_16397_1147616880456321454", "calls": 7, "avg_time_ms": 0.004145}, {"queryid": "10_16384_-5882793009925938522", "calls": 297, "avg_time_ms": 0.005175084175084175}, {"queryid": "16395_16397_3056796129964297839", "calls": 49, "avg_time_ms": 2.0516505918367347}, {"queryid": "16395_16397_-1369518071768669100", "calls": 2, "avg_time_ms": 4657.631925000001}, {"queryid": "16395_16397_7171683593826125741", "calls": 132866, "avg_time_ms": 0.2830951841629885}, {"queryid": "16395_14672_-3033217080036596150", "calls": 1408, "avg_time_ms": 0.16061142542613632}, {"queryid": "16395_16397_-4358449467818605325", "calls": 8, "avg_time_ms": 0.06592725}, {"queryid": "16395_16397_3045949496369940598", "calls": 1, "avg_time_ms": 0.004151}, {"queryid": "10_16384_7937865261479521441", "calls": 45468, "avg_time_ms": 0.16801739539896196}, {"queryid": "24596_16397_7450345460553604923", "calls": 1, "avg_time_ms": 77.198082}, {"queryid": "10_1_5125610066150999022", "calls": 7, "avg_time_ms": 0.011623714285714286}]'}}, 'local': {'database': {'pg_stat_database': {'aggregated': {'numbackends': 3, 'xact_commit': 9963793.0, 'xact_rollback': 45083.0, 'blks_read': 36889886.0, 'blks_hit': 2000157177.0, 'tup_returned': 3695551782.0, 'tup_fetched': 314221893.0, 'tup_inserted': 243341592.0, 'tup_updated': 58847823.0, 'tup_deleted': 1610.0, 'conflicts': 0.0, 'temp_files': 38.0, 'temp_bytes': 1149632512.0, 'deadlocks': 0.0, 'blk_read_time': 84692699.25400001, 'blk_write_time': 528848.044}}, 'pg_stat_database_conflicts': {'aggregated': {'confl_tablespace': 0.0, 'confl_lock': 0.0, 'confl_snapshot': 0.0, 'confl_bufferpin': 0.0, 'confl_deadlock': 0.0}}}, 'table': {'pg_stat_user_tables': {'aggregated': {}}, 'pg_statio_user_tables': {'aggregated': {}}}, 'index': {'pg_stat_user_indexes': {'aggregated': {}}, 'pg_statio_user_indexes': {'aggregated': {}}}}}, 'summary': {'version': '14.2', 'observation_time': 1660082837}, 'row_num_stats': {'num_tables': 0, 'num_empty_tables': 0, 'num_tables_row_count_0_10k': 0, 'num_tables_row_count_10k_100k': 0, 'num_tables_row_count_100k_1m': 0, 'num_tables_row_count_1m_10m': 0, 'num_tables_row_count_10m_100m': 0, 'num_tables_row_count_100m_inf': 0, 'max_row_num': None, 'min_row_num': None}, 'db_key': 'a468086d-192a-456d-96bd-14f23f138108', 'organization_id': '978a5fa7-3a7f-4ad8-9a20-670d898736cf',`**` 'non_default_knobs': ['autovacuum_vacuum_cost_delay', 'autovacuum_vacuum_cost_limit', 'autovacuum_vacuum_scale_factor', 'autovacuum_vacuum_threshold', 'bgwriter_delay', 'bgwriter_lru_maxpages', 'bgwriter_lru_multiplier', 'checkpoint_completion_target', 'checkpoint_timeout', 'default_statistics_target', 'effective_cache_size', 'effective_io_concurrency']}`**

# Background
Phase 2 of DB Check Improvement RFC: https://docs.google.com/document/d/1hM4xELsiHoWVlLKA7q0kur9X1soBRH1SYlbGAs9_JiI/edit#heading=h.b9ona1m86asy

# Test Plan
- [x] Manual Testing
- [x] Unit tests: default driver config: rds
- [ ] Error handling
- [ ] Failing MySQL and PG tests
- [ ] more unit tests for db_level_observation