### PR TITLE
OTT-2675 Default to postgres for db name

### DIFF
--- a/driver/driver_config_builder.py
+++ b/driver/driver_config_builder.py
@@ -296,9 +296,8 @@ class DriverConfigBuilder(BaseDriverConfigBuilder):
 
         if self.config["db_type"] == "postgres":
             if not db_name:
-                msg = ("Must supply database name for Postgres via environment variable: "
-                       "POSTGRES_OTTERTUNE_DB_NAME")
-                raise DriverConfigException(msg)
+                # Default to postgres
+                db_name = "postgres"
         elif self.config["db_type"] == "mysql":
             if db_name:
                 msg = "Ignoring POSTGRES_OTTERTUNE_DB_NAME as this agent is connected to a MySql db"


### PR DESCRIPTION
# What

Defaults the postgres database name to `postgres`

# Background

Since the vast majority of users will have a postgres database defined, it streamlines onboarding to assume this as the default

# Test Plan

Works on local