### PR TITLE
Support IAM authentication for RDS/Aurora

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV OTTERTUNE_OVERRIDE_QUERY_MONITOR_INTERVAL="3600"
 ENV OTTERTUNE_OVERRIDE_NUM_QUERY_TO_COLLECT="10000"
 ENV OTTERTUNE_DISABLE_SCHEMA_MONITORING="False"
 ENV OTTERTUNE_OVERRIDE_SCHEMA_MONITOR_INTERVAL="3600"
+ENV OTTERTUNE_ENABLE_AWS_IAM_AUTH="False"
 
 RUN   apt-get clean \
    && apt-get update \
@@ -53,4 +54,5 @@ CMD python3 -m driver.main --config ./driver/config/driver_config.yaml --aws-reg
   --override-query-monitor-interval $OTTERTUNE_OVERRIDE_QUERY_MONITOR_INTERVAL \
   --override-num-query-to-collect $OTTERTUNE_OVERRIDE_NUM_QUERY_TO_COLLECT \
   --disable-schema-monitoring $OTTERTUNE_DISABLE_SCHEMA_MONITORING \
-  --override-schema-monitor-interval $OTTERTUNE_OVERRIDE_SCHEMA_MONITOR_INTERVAL
+  --override-schema-monitor-interval $OTTERTUNE_OVERRIDE_SCHEMA_MONITOR_INTERVAL \
+  --enable-aws-iam-auth $OTTERTUNE_ENABLE_AWS_IAM_AUTH

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,6 @@ ENV OTTERTUNE_OVERRIDE_NUM_QUERY_TO_COLLECT="10000"
 ENV OTTERTUNE_DISABLE_SCHEMA_MONITORING="False"
 ENV OTTERTUNE_OVERRIDE_SCHEMA_MONITOR_INTERVAL="3600"
 
-
-RUN mkdir -p /ottertune/driver
-COPY . /ottertune/driver
-WORKDIR /ottertune/driver
 RUN   apt-get clean \
    && apt-get update \
    && apt-get install -yq gcc musl-dev python3-dev libpq-dev g++
@@ -36,7 +32,16 @@ RUN cp /usr/lib/ssl/openssl.cnf /usr/lib/ssl/openssl_cipher1.cnf && \
     sed -i "s/\(CipherString *= *\).*/\1DEFAULT@SECLEVEL=1 /" "/usr/lib/ssl/openssl_cipher1.cnf" && \
     sed -i "s/\(MinProtocol *= *\).*/\1TLSv1 /" "/usr/lib/ssl/openssl_cipher1.cnf"
 
+RUN mkdir -p /ottertune/driver
+WORKDIR /ottertune/driver
+# Only copy over requirements.txt so we can take advtantage of caching the
+# dependency installation steps.
+COPY ./requirements.txt /ottertune/driver/requirements.txt
+
 RUN pip install -r requirements.txt
+
+# Add source after installing deps to make iterating faster
+COPY . /ottertune/driver
 
 CMD python3 -m driver.main --config ./driver/config/driver_config.yaml --aws-region $AWS_REGION --db-identifier $OTTERTUNE_DB_IDENTIFIER  --db-username $OTTERTUNE_DB_USERNAME --db-password $OTTERTUNE_DB_PASSWORD --api-key $OTTERTUNE_API_KEY --db-key $OTTERTUNE_DB_KEY --organization-id $OTTERTUNE_ORG_ID --override-server-url $OTTERTUNE_OVERRIDE_SERVER_URL \
   --override-num-table-to-collect-stats $OTTERTUNE_OVERRIDE_NUM_TABLE_TO_COLLECT_STATS \

--- a/driver/aws/rds.py
+++ b/driver/aws/rds.py
@@ -154,3 +154,11 @@ def get_db_non_default_parameters(
         )
 
     return db_non_default_parameters
+
+
+def get_db_auth_token(
+    db_username: str, hostname: str, port: int, client: RDSClient
+) -> str:
+    return client.generate_db_auth_token(
+        DBHostname=hostname, Port=port, DBUsername=db_username
+    )

--- a/driver/driver_config_builder.py
+++ b/driver/driver_config_builder.py
@@ -166,7 +166,7 @@ class PartialConfigFromCommandline(BaseModel):  # pyre-ignore[13]: pydantic unin
     db_user: StrictStr
     db_password: StrictStr
 
-    enable_aws_iam_auth = False
+    enable_aws_iam_auth: StrictBool = False
     disable_table_level_stats: StrictBool = False
     disable_index_stats: StrictBool = False
     disable_query_monitoring: StrictBool = False

--- a/driver/driver_config_builder.py
+++ b/driver/driver_config_builder.py
@@ -417,18 +417,6 @@ class DriverConfigBuilder(BaseDriverConfigBuilder):
         self.config.update(supplied_overrides)
         return self
 
-    def from_derived(self) -> BaseDriverConfigBuilder:
-        """Generates parameters necessary, based on configurations from other parts of the builder"""
-        if self.config["enable_aws_iam_auth"]:
-            auth_token = get_db_auth_token(
-                self.config["db_user"],
-                self.config["db_host"],
-                self.config["db_port"],
-                self.rds_client,
-            )
-            self.config.update({"db_password": auth_token})
-        return self
-
     def get_config(self) -> DriverConfig:
         """Get driver configuration for on-prem deployment.
 

--- a/driver/main.py
+++ b/driver/main.py
@@ -203,8 +203,7 @@ def get_config(args):
                   .from_cloudwatch_metrics(args.db_identifier)\
                   .from_command_line(args)\
                   .from_env_vars()\
-                  .from_overrides(overrides)\
-                  .from_derived()
+                  .from_overrides(overrides)
 
     config = config_builder.get_config()
 

--- a/driver/main.py
+++ b/driver/main.py
@@ -57,8 +57,9 @@ def _get_args() -> argparse.Namespace:
     parser.add_argument(
         "--db-password",
         type=str,
-        help="Password used for db connection",
-        required=True
+        help="Password used for db connection (Required unless --enable-aws-iam-auth is set to True)",
+        nargs="?",
+        default="",
     )
     parser.add_argument(
         "--api-key",
@@ -135,12 +136,18 @@ def _get_args() -> argparse.Namespace:
         "--disable-schema-monitoring",
         type=str,
         default="False",
-        help="Whether to disable schema monitoring."
+        help="Whether to disable schema monitoring.",
     )
     parser.add_argument(
         "--override-schema-monitor-interval",
         type=int,
         help="Override file setting for how often to collect schema data (in seconds)",
+    )
+    parser.add_argument(
+        "--enable-aws-iam-auth",
+        type=str,
+        default="False",
+        help="Use AWS IAM auth when connecting to DB",
     )
 
     return parser.parse_args()
@@ -196,7 +203,8 @@ def get_config(args):
                   .from_cloudwatch_metrics(args.db_identifier)\
                   .from_command_line(args)\
                   .from_env_vars()\
-                  .from_overrides(overrides)
+                  .from_overrides(overrides)\
+                  .from_derived()
 
     config = config_builder.get_config()
 

--- a/tests/collector_factory_test.py
+++ b/tests/collector_factory_test.py
@@ -2,7 +2,7 @@
 Tests for the collector factory
 """
 from typing import Dict, Any, NoReturn
-from unittest.mock import MagicMock
+from unittest.mock import (MagicMock, patch)
 import mock
 import pytest
 import mysql.connector.connection
@@ -58,6 +58,30 @@ def test_db_config_mysql_success() -> None:
     db_conf_new = create_db_config_mysql(driver_conf)
     assert expected_db_conf == db_conf_new
 
+def test_db_config_mysql_iam_auth() -> None:
+    with patch('driver.collector.collector_factory.get_db_auth_token') as mocked_db_auth_token:
+        mocked_db_auth_token.return_value = 'auth_token'
+
+        driver_conf: Dict[str, Any] = {
+            "db_host": "localhost",
+            "db_port": "3306",
+            "db_user": "test_user",
+            "db_password": "test_password",
+            "db_name": "test_db",
+            "db_version": "8.0.22",
+            "aws_region": "us-east-1",
+            "enable_aws_iam_auth": True
+        }
+        expected_db_conf: Dict[str, Any] = {
+            "host": "localhost",
+            "port": "3306",
+            "user": "test_user",
+            "password": "auth_token",
+            "database": "test_db",
+            "charset": "utf8",
+        }
+        db_conf = create_db_config_mysql(driver_conf)
+        assert expected_db_conf == db_conf
 
 def test_db_config_mysql_invalid() -> None:
     driver_conf: Dict[str, Any] = {
@@ -111,6 +135,30 @@ def test_db_config_postgres_success() -> None:
     expected_db_conf["dbname"] = "postgres"
     db_conf_new = create_db_config_postgres(driver_conf)
     assert expected_db_conf == db_conf_new
+
+def test_db_config_postgres_iam_auth() -> None:
+    with patch('driver.collector.collector_factory.get_db_auth_token') as mocked_db_auth_token:
+        mocked_db_auth_token.return_value = 'auth_token'
+
+        driver_conf: Dict[str, Any] = {
+            "db_host": "localhost",
+            "db_port": "3306",
+            "db_user": "test_user",
+            "db_password": "test_password",
+            "db_name": "test_db",
+            "db_version": "8.0.22",
+            "aws_region": "us-east-1",
+            "enable_aws_iam_auth": True
+        }
+        expected_db_conf: Dict[str, Any] = {
+            "host": "localhost",
+            "port": "3306",
+            "user": "test_user",
+            "password": "auth_token",
+            "dbname": "test_db",
+        }
+        db_conf = create_db_config_postgres(driver_conf)
+        assert expected_db_conf == db_conf
 
 
 def test_db_config_postgres_invalid() -> None:

--- a/tests/config_builder_test.py
+++ b/tests/config_builder_test.py
@@ -240,25 +240,3 @@ def test_partial_config_from_file_invalid_schema_interval(
     with pytest.raises(ValidationError) as ex:
         PartialConfigFromFile(**test_data_from_file)
     assert "schema_monitor_interval" in str(ex.value)
-
-
-def test_from_derived_with_use_iam() -> None:
-    config_builder = DriverConfigBuilder('us-east-2')
-    with patch("driver.driver_config_builder.get_db_auth_token") as mocked_db_auth_token:
-        mocked_db_auth_token.return_value = 'auth_token'
-        config_builder.config.update({"db_user": 'test_user', 'db_password': 'password',
-                                      'db_host': 'localhost', 'db_port': 3306, 'enable_aws_iam_auth': True})
-        config_builder.from_derived()
-
-        assert config_builder.config['db_password'] == 'auth_token'
-
-
-def test_from_derived_not_use_iam() -> None:
-    config_builder = DriverConfigBuilder('us-east-2')
-    with patch("driver.driver_config_builder.get_db_auth_token") as mocked_db_auth_token:
-        mocked_db_auth_token.return_value = 'auth_token'
-        config_builder.config.update({"db_user": 'test_user', 'db_password': 'password',
-                                      'db_host': 'localhost', 'db_port': 3306, 'enable_aws_iam_auth': False})
-        config_builder.from_derived()
-
-        assert config_builder.config['db_password'] == 'password'

--- a/tests/config_builder_test.py
+++ b/tests/config_builder_test.py
@@ -247,7 +247,7 @@ def test_from_derived_with_use_iam() -> None:
     with patch("driver.driver_config_builder.get_db_auth_token") as mocked_db_auth_token:
         mocked_db_auth_token.return_value = 'auth_token'
         config_builder.config.update({"db_user": 'test_user', 'db_password': 'password',
-                                      'db_host': 'localhost', 'db_port': 3306, 'use_aws_iam_auth': True})
+                                      'db_host': 'localhost', 'db_port': 3306, 'enable_aws_iam_auth': True})
         config_builder.from_derived()
 
         assert config_builder.config['db_password'] == 'auth_token'
@@ -258,7 +258,7 @@ def test_from_derived_not_use_iam() -> None:
     with patch("driver.driver_config_builder.get_db_auth_token") as mocked_db_auth_token:
         mocked_db_auth_token.return_value = 'auth_token'
         config_builder.config.update({"db_user": 'test_user', 'db_password': 'password',
-                                      'db_host': 'localhost', 'db_port': 3306, 'use_aws_iam_auth': False})
+                                      'db_host': 'localhost', 'db_port': 3306, 'enable_aws_iam_auth': False})
         config_builder.from_derived()
 
         assert config_builder.config['db_password'] == 'password'

--- a/tests/config_builder_test.py
+++ b/tests/config_builder_test.py
@@ -240,3 +240,25 @@ def test_partial_config_from_file_invalid_schema_interval(
     with pytest.raises(ValidationError) as ex:
         PartialConfigFromFile(**test_data_from_file)
     assert "schema_monitor_interval" in str(ex.value)
+
+
+def test_from_derived_with_use_iam() -> None:
+    config_builder = DriverConfigBuilder('us-east-2')
+    with patch("driver.driver_config_builder.get_db_auth_token") as mocked_db_auth_token:
+        mocked_db_auth_token.return_value = 'auth_token'
+        config_builder.config.update({"db_user": 'test_user', 'db_password': 'password',
+                                      'db_host': 'localhost', 'db_port': 3306, 'use_aws_iam_auth': True})
+        config_builder.from_derived()
+
+        assert config_builder.config['db_password'] == 'auth_token'
+
+
+def test_from_derived_not_use_iam() -> None:
+    config_builder = DriverConfigBuilder('us-east-2')
+    with patch("driver.driver_config_builder.get_db_auth_token") as mocked_db_auth_token:
+        mocked_db_auth_token.return_value = 'auth_token'
+        config_builder.config.update({"db_user": 'test_user', 'db_password': 'password',
+                                      'db_host': 'localhost', 'db_port': 3306, 'use_aws_iam_auth': False})
+        config_builder.from_derived()
+
+        assert config_builder.config['db_password'] == 'password'


### PR DESCRIPTION
# What

Add support for IAM based authentication against RDS/Aurora databases.

- Adds a new parameter (`--enable-aws-iam-auth`) to indicate that IAM auth should be used.
    - This flag sssumes that the supplied AWS credentials have sufficient permissions to connect the database
- Rearrange Dockerfile to take better advantage of layer caching (speeds up iteration when leveraging the container)
- `db_password` is not required if `--enable-aws-iam-auth` is set

# Background

At my company we prefer IAM based authentication, and would like to not create password based users if possible. This also seems like a useful feature in general.

AWS Documentation: https://github.com/awslabs/aws-mysql-jdbc#aws-iam-database-authentication

# Test Plan

- Added some tests for the config builder.
- Tested manually using `docker run` against a database with an IAM based user.
