### PR TITLE
Make the postgres_db_list optional

### DIFF
--- a/driver/collector/collector_factory.py
+++ b/driver/collector/collector_factory.py
@@ -254,10 +254,11 @@ def get_collector(
         elif driver_conf["db_type"] in ["postgres", "aurora_postgresql"]:
             pg_conf = create_db_config_postgres(driver_conf)
             conns: Dict[str, Any] = {}
-            for logical_database in driver_conf["postgres_db_list"]:
-                pg_conf_logical = pg_conf.copy()
-                pg_conf_logical["dbname"] = logical_database
-                conns[logical_database] = connect_postgres(pg_conf_logical)
+            if driver_conf['postgres_db_list'] is not None:
+                for logical_database in driver_conf["postgres_db_list"]:
+                    pg_conf_logical = pg_conf.copy()
+                    pg_conf_logical["dbname"] = logical_database
+                    conns[logical_database] = connect_postgres(pg_conf_logical)
 
             main_db = pg_conf["dbname"]
             conns[main_db] = connect_postgres(pg_conf)

--- a/driver/config/driver_config.yaml
+++ b/driver/config/driver_config.yaml
@@ -27,4 +27,3 @@ num_index_to_collect_stats: 10000
 query_monitor_interval: 3600
 num_query_to_collect: 10000
 schema_monitor_interval: 3600
-postgres_db_list: ["postgres"]


### PR DESCRIPTION
# What

Makes the `postgres_db_list` optional

# Background

This will maintain backwards compatibility and make the API simpler for users who only have one logical database. 

# Test Plan

Works on local. 