### PR TITLE
fix Postgres table stats collector for aurora reader

### DIFF
--- a/driver/collector/pg_table_level_stats_sqls.py
+++ b/driver/collector/pg_table_level_stats_sqls.py
@@ -8,8 +8,8 @@ FROM
 WHERE
   n_live_tup + seq_scan + idx_scan > 0
 ORDER BY
-  n_live_tup, seq_scan + idx_scan desc
-DESC LIMIT
+  n_live_tup DESC, seq_scan + idx_scan DESC
+LIMIT
   {n};
 """
 

--- a/driver/collector/pg_table_level_stats_sqls.py
+++ b/driver/collector/pg_table_level_stats_sqls.py
@@ -6,9 +6,9 @@ SELECT
 FROM
   pg_stat_user_tables
 WHERE
-  n_live_tup > 0
+  n_live_tup + seq_scan + idx_scan > 0
 ORDER BY
-  n_live_tup
+  n_live_tup, seq_scan + idx_scan desc
 DESC LIMIT
   {n};
 """

--- a/tests/db_test_postgres.py
+++ b/tests/db_test_postgres.py
@@ -298,7 +298,7 @@ def test_collect_table_level_data_from_database(
     assert summary["observation_time"] > 0
     assert len(version_str) > 0
     # 0 as the database is empty
-    _verify_postgres_table_level_data(data, 2)
+    _verify_postgres_table_level_data(data, 3)
 
 
 def test_postgres_collect_table_level_metrics(
@@ -340,7 +340,7 @@ def test_postgres_collect_table_level_metrics(
     metrics = collector.collect_table_level_metrics(target_table_info)
     metrics.update(collector.collect_index_metrics(target_table_info, num_index_to_collect_stats))
 
-    _verify_postgres_table_level_data(metrics, 2)
+    _verify_postgres_table_level_data(metrics, 3)
 
 
 def test_postgres_collect_index_metrics(


### PR DESCRIPTION
# What
For Postgres Aurora reader, the number of rows for each table is 0 in table statistics since it never gets updated. This is because Aurora reader is read-only, and Analyze is not allowed. We should not filter out tables only based on the metric n_live_tup


# Background



# Test Plan

