### PR TITLE
Fix S3 bug for table level observation data

### DIFF
--- a/agent_version.py
+++ b/agent_version.py
@@ -1,2 +1,2 @@
 # TODO: move this elsewhere and have it pull from git tags as source of truth
-AGENT_VERSION = "0.5.3"
+AGENT_VERSION = "0.5.4"

--- a/driver/s3_client.py
+++ b/driver/s3_client.py
@@ -31,7 +31,7 @@ OT_BUCKET_NAME = "customer-database-observations"  # OtterTune S3 bucket name
 class S3Client:
     """S3 client that interacts with the OtterTune S3 bucket."""
 
-    def __init__( # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         enable_s3,
         aws_region,
@@ -47,7 +47,7 @@ class S3Client:
         self._api_key = api_key
         self._s3_bucket_name = s3_bucket_name
 
-    def get_s3_session(): # pylint: disable=no-method-argument
+    def get_s3_session():  # pylint: disable=no-method-argument
         """Get the S3 session for operation in OtterTune S3 bucket."""
 
         session = boto3.Session()
@@ -73,12 +73,18 @@ class S3Client:
             ObservationType.LONG_RUNNING_QUERY.value,
             ObservationType.SCHEMA.value,
         ):
+            # Add headers to the compressed data
+            data["headers"]["Content-Type"] = "application/json; charset=utf-8"
+            data["headers"]["Content-Encoding"] = "gzip"
             compressed_data = zlib.compress(
                 json.dumps(data, default=str).encode("utf-8")
             )
             return compressed_data
 
-        serialized_data = json.dumps(data).encode("utf-8")
+        if obs_type.value == ObservationType.TABLE.value:
+            data["headers"]["Content-Type"] = "application/json"
+
+        serialized_data = json.dumps(data, default=str).encode("utf-8")
         return serialized_data
 
     def get_s3_bucket_object_key(self, obs_type: ObservationType):

--- a/tests/s3_client_test.py
+++ b/tests/s3_client_test.py
@@ -4,6 +4,7 @@ Tests for the S3 client
 import zlib
 import json
 import datetime
+from typing import Any, Dict
 
 from agent_version import AGENT_VERSION
 from driver.s3_client import S3Client, ObservationType
@@ -70,7 +71,7 @@ def test_process_observation_data() -> None:
         db_key="fed922a6-0cbc-429c-bbbd-fe4ef843421f",
         api_key="test_api_key",
     )
-    observation_data = {
+    observation_data: Dict[str, Any] = {
         "key1": "value1",
     }
     observation_data["headers"] = client.generate_headers()
@@ -80,10 +81,8 @@ def test_process_observation_data() -> None:
     decompressed_data = zlib.decompress(processed_observation_data).decode("utf-8")
     assert isinstance(processed_observation_data, bytes), True
     assert decompressed_data, json.dumps(observation_data, default=str)
-    assert observation_data["headers"][
-        "Content-Type"
-    ], "application/json; charset=utf-8"
-    assert observation_data["headers"]["Content-Encoding"], "gzip"
+    assert observation_data["headers"]["Content-Type"] == "application/json; charset=utf-8"
+    assert observation_data["headers"]["Content-Encoding"] == "gzip"
 
     observation_data["headers"] = client.generate_headers()
     processed_observation_data = client.process_observation_data(
@@ -92,10 +91,8 @@ def test_process_observation_data() -> None:
     decompressed_data = zlib.decompress(processed_observation_data).decode("utf-8")
     assert isinstance(processed_observation_data, bytes), True
     assert decompressed_data, json.dumps(observation_data, default=str)
-    assert observation_data["headers"][
-        "Content-Type"
-    ], "application/json; charset=utf-8"
-    assert observation_data["headers"]["Content-Encoding"], "gzip"
+    assert observation_data["headers"]["Content-Type"] == "application/json; charset=utf-8"
+    assert observation_data["headers"]["Content-Encoding"] == "gzip"
 
     observation_data["headers"] = client.generate_headers()
     processed_observation_data = client.process_observation_data(
@@ -104,10 +101,8 @@ def test_process_observation_data() -> None:
     decompressed_data = zlib.decompress(processed_observation_data).decode("utf-8")
     assert isinstance(processed_observation_data, bytes), True
     assert decompressed_data, json.dumps(observation_data, default=str)
-    assert observation_data["headers"][
-        "Content-Type"
-    ], "application/json; charset=utf-8"
-    assert observation_data["headers"]["Content-Encoding"], "gzip"
+    assert observation_data["headers"]["Content-Type"] == "application/json; charset=utf-8"
+    assert observation_data["headers"]["Content-Encoding"] == "gzip"
 
     observation_data["headers"] = client.generate_headers()
     processed_observation_data = client.process_observation_data(


### PR DESCRIPTION
# What
"default=str" is required to serialize "datetime" object:
serialized_data = json.dumps(data, default=str).encode("utf-8")


# Background



# Test Plan

